### PR TITLE
reduce to the ruby versions we are using

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,8 @@ workflows:
           context: org-global
           matrix:
             parameters:
-              node_version: ['12', '14', '15', '16']
-              ruby_version: ['2.6.5', '2.6.6', '2.6.7', '2.7.1', '2.7.4', '2.7.2', '2.7.3', '2.7.4','2.7.5', '3.0.1']
+              node_version: ['12', '15', '16']
+              ruby_version: ['2.6.5', '2.7.1', '2.7.3', '2.7.5']
           filters:
             branches:
               only:


### PR DESCRIPTION
I looked to see what was currently being used in our ruby projects, and only kept those versions. separate tickets should probably be made for upgrading old versions in their respective projects 