### PR TITLE
reduces matrix builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
   trivy_check:
     triggers:
       - schedule:
-          cron: '15 4 * * *'
+          cron: '15 4 * * 1'
           filters:
             branches:
               only:
@@ -84,8 +84,8 @@ workflows:
           context: org-global
           matrix:
             parameters:
-              node_version: ['12', '14', '16', '18']
-              ruby_version: ['2.6.5', '2.7.1', '2.7.3', '2.7.4', '2.7.5', '2.7.6', '3.1.2']
+              node_version: ['12','16', '18']
+              ruby_version: ['2.7.3', '2.7.6', '3.1.2']
           filters:
             branches:
               only:
@@ -97,8 +97,8 @@ workflows:
           context: org-global
           matrix:
             parameters:
-              node_version: ['12', '14', '16', '18']
-              ruby_version: ['2.6.5', '2.7.1', '2.7.3', '2.7.4', '2.7.5', '2.7.6', '3.1.2']
+              node_version: ['12','16', '18']
+              ruby_version: ['2.7.3', '2.7.6', '3.1.2']
           filters:
             branches:
               only:


### PR DESCRIPTION
- removes unsupported rubies / node 
- only runs trivy weekly.