### PR TITLE
cleans up ruby-base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ workflows:
           context: org-global
           matrix:
             parameters:
-              node_version: ['12','16', '18']
-              ruby_version: ['2.7.3', '2.7.6', '3.1.2', '3.1.3', '3.2.0']
+              node_version: ['16', '18']
+              ruby_version: ['3.1.2', '3.1.3', '3.2.2']
           filters:
             branches:
               only:
@@ -97,8 +97,8 @@ workflows:
           context: org-global
           matrix:
             parameters:
-              node_version: ['12','16', '18']
-              ruby_version: ['2.7.3', '2.7.6', '3.1.2', '3.1.3', '3.2.1']
+              node_version: ['16', '18']
+              ruby_version: ['3.1.2', '3.1.3', '3.2.2']
           filters:
             branches:
               only:


### PR DESCRIPTION
I didn't see old node, or ruby being used anywhere 

https://github.com/search?q=org%3Apsu-libraries++FROM+harbor.k8s.libraries.psu.edu%2Flibrary%2Fruby&type=code