### PR TITLE
Revert "updating ruby from 2.7.1 to 3.3.6"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG RUBY_VERSION=3.3.6
-FROM ruby:${RUBY_VERSION}-slim-bullseye as base
+ARG RUBY_VERSION=2.7.1
+FROM ruby:${RUBY_VERSION}-slim-buster as base
 
 ENV TZ=America/New_York
 


### PR DESCRIPTION
Reverts psu-libraries/ruby-base#9