### PR TITLE
Rename node_version to node_major in CI and Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-      node_version:
+      node_major:
         type: string
     docker:
       - image: harbor.k8s.libraries.psu.edu/library/ci-utils:v4.6.1
@@ -37,15 +37,15 @@ jobs:
       - run:
           name: "trivy"
           command: |
-            export BUILD_ARGS="--build-arg RUBY_VERSION=<< parameters.ruby_version >> --build-arg NODE_MAJOR=<< parameters.node_version >>"
-            export REGISTRY_IMAGE=$REGISTRY_URL-<< parameters.ruby_version >>-node-<< parameters.node_version >>
+            export BUILD_ARGS="--build-arg RUBY_VERSION=<< parameters.ruby_version >> --build-arg NODE_MAJOR=<< parameters.node_major >>"
+            export REGISTRY_IMAGE=$REGISTRY_URL-<< parameters.ruby_version >>-node-<< parameters.node_major >>
             export IMAGE_TAG="$(date +%Y%m%d),latest"
             /usr/local/bin/trivy-check
   build-and-push:
     parameters:
       ruby_version:
         type: string
-      node_version:
+      node_major:
         type: string
     docker:
       - image: harbor.k8s.libraries.psu.edu/library/ci-utils:$CI_UTILS_IMAGE_TAG
@@ -58,8 +58,8 @@ jobs:
       - run:
           name: "build and push"
           command: |
-            export BUILD_ARGS="--build-arg RUBY_VERSION=<< parameters.ruby_version >> --build-arg NODE_MAJOR=<< parameters.node_version >>"
-            export REGISTRY_IMAGE=$REGISTRY_URL-<< parameters.ruby_version >>-node-<< parameters.node_version >>
+            export BUILD_ARGS="--build-arg RUBY_VERSION=<< parameters.ruby_version >> --build-arg NODE_MAJOR=<< parameters.node_major >>"
+            export REGISTRY_IMAGE=$REGISTRY_URL-<< parameters.ruby_version >>-node-<< parameters.node_major >>
             export IMAGE_TAG="$(date +%Y%m%d),latest"
             /usr/local/bin/build-and-push
 workflows:
@@ -80,7 +80,7 @@ workflows:
           context: org-global
           matrix:
             parameters:
-              node_version: ['22','22']
+              node_major: ['22']
               ruby_version: ['3.4.1','3.4.9']
           filters:
             branches:
@@ -93,7 +93,7 @@ workflows:
           context: org-global
           matrix:
             parameters:
-              node_version: ['22','22']
+              node_major: ['22']
               ruby_version: ['3.4.1','3.4.9']
           filters:
             branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ ENV TZ=America/New_York
 
 WORKDIR /app
 
-ARG NODE_VERSION=22
+ARG NODE_MAJOR=22
+ARG NODE_VERSION=${NODE_MAJOR}
 ARG YARN_VERSION=1.22.22
 ARG BUNDLER_VERSION=2.6.3
-ENV RUBY_BASE_IMAGE=${RUBY_VERSION}-node-${NODE_VERSION}
+ENV RUBY_BASE_IMAGE=${RUBY_VERSION}-node-${NODE_MAJOR}
 
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
@@ -19,7 +20,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add Node.js repository
-RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash - && \
     mkdir -p /etc/apt/keyrings
 
 # Install Node.js and build tools, then pin Yarn via Corepack


### PR DESCRIPTION
- Updated parameter names in CircleCI config to reflect the change from node_version to node_major.
- Adjusted build commands to use the new parameter name.
- Modified Dockerfile to align with the updated ARG for Node.js version.