### PR TITLE
Yarn upgrades

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,17 @@ jobs:
             /usr/local/bin/build-and-push
 workflows:
   trivy_check:
+    triggers:
+        - schedule:
+          # Cron fields: <minute> <hour> <day-of-month> <month> <day-of-week>
+          # Runs at 04:15 on the 1st day every 2nd month.
+          # Months selected by '*/2' in the month field: 1,3,5,7,9,11 (Jan, Mar, May, Jul, Sep, Nov).
+          # Goal is to get dependabot  PR's to keep these images up to date with security updates.
+          cron: '15 4 1 */2 *'
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - create-db:
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
         type: string
       node_major:
         type: string
+      yarn_version:
+        type: string
     docker:
       - image: harbor.k8s.libraries.psu.edu/library/ci-utils:v4.6.1
     environment:
@@ -37,8 +39,8 @@ jobs:
       - run:
           name: "trivy"
           command: |
-            export BUILD_ARGS="--build-arg RUBY_VERSION=<< parameters.ruby_version >> --build-arg NODE_MAJOR=<< parameters.node_major >>"
-            export REGISTRY_IMAGE=$REGISTRY_URL-<< parameters.ruby_version >>-node-<< parameters.node_major >>
+            export BUILD_ARGS="--build-arg RUBY_VERSION=<< parameters.ruby_version >> --build-arg NODE_MAJOR=<< parameters.node_major >> --build-arg YARN_VERSION=<< parameters.yarn_version >>"
+            export REGISTRY_IMAGE=$REGISTRY_URL-<< parameters.ruby_version >>-node-<< parameters.node_major >>-yarn-<< parameters.yarn_version >>
             export IMAGE_TAG="$(date +%Y%m%d),latest"
             /usr/local/bin/trivy-check
   build-and-push:
@@ -46,6 +48,8 @@ jobs:
       ruby_version:
         type: string
       node_major:
+        type: string
+      yarn_version:
         type: string
     docker:
       - image: harbor.k8s.libraries.psu.edu/library/ci-utils:$CI_UTILS_IMAGE_TAG
@@ -58,8 +62,8 @@ jobs:
       - run:
           name: "build and push"
           command: |
-            export BUILD_ARGS="--build-arg RUBY_VERSION=<< parameters.ruby_version >> --build-arg NODE_MAJOR=<< parameters.node_major >>"
-            export REGISTRY_IMAGE=$REGISTRY_URL-<< parameters.ruby_version >>-node-<< parameters.node_major >>
+            export BUILD_ARGS="--build-arg RUBY_VERSION=<< parameters.ruby_version >> --build-arg NODE_MAJOR=<< parameters.node_major >> --build-arg YARN_VERSION=<< parameters.yarn_version >>"
+            export REGISTRY_IMAGE=$REGISTRY_URL-<< parameters.ruby_version >>-node-<< parameters.node_major >>-yarn-<< parameters.yarn_version >>
             export IMAGE_TAG="$(date +%Y%m%d),latest"
             /usr/local/bin/build-and-push
 workflows:
@@ -86,6 +90,7 @@ workflows:
             parameters:
               node_major: ['22']
               ruby_version: ['3.4.9']
+              yarn_version: ['1.22.22', '4.16.0']
           filters:
             branches:
               only:
@@ -99,6 +104,7 @@ workflows:
             parameters:
               node_major: ['22']
               ruby_version: ['3.4.9']
+              yarn_version: ['4.16.0', '4.15.0']
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       yarn_version:
         type: string
     docker:
-      - image: harbor.k8s.libraries.psu.edu/library/ci-utils:v4.6.1
+      - image: harbor.k8s.libraries.psu.edu/library/ci-utils:v4.6.4
     environment:
       REGISTRY_URL: library/ruby
       TRIVY_CACHE_DIR: trivy-db

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,11 +69,11 @@ jobs:
 workflows:
   trivy_check:
     triggers:
-        - schedule:
+      - schedule:
           # Cron fields: <minute> <hour> <day-of-month> <month> <day-of-week>
           # Runs at 04:15 on the 1st day every 2nd month.
           # Months selected by '*/2' in the month field: 1,3,5,7,9,11 (Jan, Mar, May, Jul, Sep, Nov).
-          # Goal is to get dependabot  PR's to keep these images up to date with security updates.
+          # Goal is to get dependabot PRs to keep these images up to date with security updates.
           cron: '15 4 1 */2 *'
           filters:
             branches:
@@ -104,7 +104,7 @@ workflows:
             parameters:
               node_major: ['22']
               ruby_version: ['3.4.9']
-              yarn_version: ['4.16.0', '4.15.0']
+              yarn_version: ['1.22.22', '4.16.0']
           filters:
             branches:
               only:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 ARG NODE_MAJOR=22
 ARG NODE_VERSION=${NODE_MAJOR}
-ARG YARN_VERSION=1.22.22
+ARG YARN_VERSION=4.16.0
 ARG BUNDLER_VERSION=2.6.3
 ENV RUBY_BASE_IMAGE=${RUBY_VERSION}-node-${NODE_MAJOR}
 
@@ -23,7 +23,7 @@ RUN apt-get update && \
 RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash - && \
     mkdir -p /etc/apt/keyrings
 
-# Install Node.js and build tools, then pin Yarn via Corepack
+# Install Node.js and build tools, then pin Yarn v4 via Corepack
 RUN apt-get update && \
 apt-get install -y --no-install-recommends \
 nodejs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,16 @@ RUN apt-get update && \
 RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash - && \
     mkdir -p /etc/apt/keyrings
 
-# Install Node.js and build tools, then pin Yarn v4 via Corepack
+# Install Node.js and build tools, then pin Yarn via Corepack
 RUN apt-get update && \
-apt-get install -y --no-install-recommends \
-nodejs \
-git make pkg-config libxslt-dev libxml2-dev g++ \
-libpq-dev libghc-zlib-dev zlib1g-dev && \
-corepack enable && \
-corepack prepare yarn@${YARN_VERSION} --activate && \
-apt-get autoremove -y && \
-apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends \
+        nodejs \
+        git make pkg-config libxslt-dev libxml2-dev g++ \
+        libpq-dev libghc-zlib-dev zlib1g-dev && \
+    corepack enable && \
+    corepack prepare yarn@${YARN_VERSION} --activate && \
+    apt-get autoremove -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # # Set up the Chrome repository - Chromie is about 130 mb smaller than chromium
 RUN echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
+# Building the Docker file locally:
+```bash
+docker build -t ruby-base .
+```
+
+# Publishing a new image for other apps to use:
+- Make the required changes (e.g. update Ruby or Yarn)
+- Commit, push and let CI build and publish.
+
+# Otherwise
+If goal is to update packages and nothing else changes:
+- Rerun the last CircleCI pipeline from the project UI to rebuild and publish the image.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Building the Docker file locally:
 ```bash
 docker build -t ruby-base .
+docker run -it ruby-base /bin/bash
+
+Specific versions
+ docker build --build-arg RUBY_VERSION=3.4.9 --build-arg NODE_MAJOR=22 --build-arg YARN_VERSION=4.16.0 -t library/ruby-3.4.9-node-22-yarn-4.16.0 .
 ```
 
 # Publishing a new image for other apps to use:


### PR DESCRIPTION
This pull request updates the Docker build and CI configuration to support multiple Yarn versions and improves the documentation for building and publishing Docker images. The main changes are the addition of a `yarn_version` parameter throughout the CI pipeline, support for building images with different Yarn versions, and a documentation update in the `README.md`.

**CI/CD pipeline enhancements:**

* Added a `yarn_version` parameter to the jobs and workflows in `.circleci/config.yml`, enabling the pipeline to build images with multiple Yarn versions. The image tags and build arguments now include the Yarn version for better traceability. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R26-R29) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L40-R43) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R52-R53) [[4]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L61-R81) [[5]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R93) [[6]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R107)
* Updated the CI utility Docker image from `v4.6.1` to `v4.6.4` for the `trivy` job, ensuring the latest tools are used.
* Added a scheduled workflow trigger to run the `trivy_check` job bi-monthly on the master branch, helping keep images up to date with security updates.

**Dockerfile update:**

* Changed the default `YARN_VERSION` in the `Dockerfile` from `1.22.22` to `4.16.0` to use the latest Yarn version by default.

**Documentation:**

* Added a section to `README.md` with instructions for building and publishing the Docker image locally and via CI.